### PR TITLE
fixed custom-builds Bassplate guide's localhost address

### DIFF
--- a/templates/docs/guides/custom-builds/index.md
+++ b/templates/docs/guides/custom-builds/index.md
@@ -23,7 +23,7 @@ npm install
 npm start
 ```
 
-This will start a server at `http://localhost:8000` and watch the `/src` folder for changes.
+This will start a server at `http://localhost:8080` and watch the `/src` folder for changes.
 Edit the files in `/src/css` to customize the compiled stylesheet.
 
 


### PR DESCRIPTION
Changed the local server address Bassplate spins up from http://localhost:8000 to http://localhost:8080.